### PR TITLE
refactor: Simplify Maven Central publishing with vanniktech plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,56 +1,26 @@
-name: Publish to Maven Central
-
+name: Publish
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 1.0.0)'
-        required: true
-        default: '1.0.0'
-
+  release:
+    types: [released, prereleased]
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    name: Release build and publish
+    runs-on: macOS-latest
     steps:
-      - name: Checkout
+      - name: Check out code
         uses: actions/checkout@v4
-
-      - name: Extract version from tag
-        id: extract_version
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          if [ -z "$VERSION" ]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "Extracted version: $VERSION"
-
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
-
-      - name: Update library version in gradle.properties
-        run: |
-          sed -i.bak "s/library.version=.*/library.version=$VERSION/" gradle.properties
-          cat gradle.properties
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: wrapper
-
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-
-      - name: Publish to Maven Central
-        run: ./gradlew publishAllPublicationsToCentralRepository --no-daemon
+          distribution: 'zulu'
+          java-version: 21
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Publish to MavenCentral
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }} 
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Publishing to Maven Central
 
-ZodKmp is published to Maven Central. The library is configured to be published through Sonatype OSSRH.
+ZodKmp is published to Maven Central. The library is configured to be published using the vanniktech Maven Publish plugin.
 
 ### Prerequisites for Publishing
 
@@ -485,10 +485,11 @@ ZodKmp is published to Maven Central. The library is configured to be published 
 3. **GitHub Secrets**: For automated publishing, configure the following secrets in your GitHub repository:
 
 ```bash
-OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }} 
-SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }} 
+SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
 SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+GPG_KEY_CONTENTS: ${{ secrets.GPG_KEY_CONTENTS }}
 ```
 
 4. **Library Version**: The version is managed in `gradle.properties`:
@@ -503,24 +504,16 @@ The library uses GitHub Actions for automated releases and publishing. For detai
 
 #### Creating a New Release
 
-1. **Via GitHub UI**: Use the "Create Release" workflow in the GitHub Actions tab
-2. **Manual Tagging**: Push a git tag in the format `vX.Y.Z` (e.g., `v1.0.0`)
-
-The process will:
-- Update the version in `gradle.properties`
-- Create a Git tag
-- Create a GitHub release
-- Automatically publish to Maven Central
+1. **Via GitHub UI**: Create a new release in the GitHub releases page with a tag in the format `vX.Y.Z` (e.g., `v1.0.0`)
+2. **The workflow** `.github/workflows/publish.yml` will automatically trigger and publish to Maven Central
 
 ### Verification
 
 To verify artifacts locally before publishing to Maven Central:
 
 ```bash
-./gradlew publishAllPublicationsToLocalRepository
+./gradlew publishToMavenCentral --no-configuration-cache
 ```
-
-This will publish to a local repository under the build directory for testing.
 
 ### Manual Publishing
 
@@ -535,10 +528,23 @@ For manual publishing (if needed):
 2. **Publish**: Publish to Sonatype OSSRH:
 
 ```bash
-./gradlew publishAllPublicationsToCentralRepository
+./gradlew publishToMavenCentral --no-configuration-cache
 ```
 
-3. **Close and Release**: After successful upload, go to [Sonatype OSSRH](https://s01.oss.sonatype.org/) to close the staging repository and release it to Maven Central.
+The vanniktech plugin handles publishing automatically to Maven Central.
+
+### Required Properties
+
+The following properties are required for Maven Central compliance and are defined in `gradle.properties`:
+
+- `GROUP` - The Maven group ID (e.g., `io.github.piashcse`)
+- `POM_ARTIFACT_ID` - The artifact ID (e.g., `zodkmp`)
+- `POM_NAME` - The display name of the library
+- `POM_DESCRIPTION` - A description of the library
+- `POM_URL` - The project URL
+- `POM_LICENSE_NAME`, `POM_LICENSE_URL` - License information
+- `POM_DEVELOPER_ID`, `POM_DEVELOPER_NAME`, `POM_DEVELOPER_EMAIL` - Developer information
+- `POM_SCM_URL`, `POM_SCM_CONNECTION`, `POM_SCM_DEV_CONNECTION` - Source code management information
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 // Set the version for the library
 allprojects {
     version = providers.gradleProperty("library.version").getOrElse("1.0.0")
-    group = "io.github.piashcse"
+    group = providers.gradleProperty("GROUP").getOrElse("io.github.piashcse")
 }
 
 // Configure repositories for publishing

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,25 @@ android.useAndroidX=true
 SONATYPE_HOST=CENTRAL
 RELEASE_SIGNING_ENABLED=true
 
-# Library
+# Library coordinates
 library.version=1.0.0
+GROUP=io.github.piashcse
+POM_ARTIFACT_ID=zodkmp
+
+# POM metadata
+POM_NAME=ZodKmp
+POM_DESCRIPTION=A Kotlin Multiplatform library for Zod-like validation
+POM_INCEPTION_YEAR=2024
+POM_URL=https://github.com/piashcse/zodkmp
+
+POM_LICENSE_NAME=MIT License
+POM_LICENSE_URL=https://opensource.org/licenses/MIT
+POM_LICENSE_DIST=repo
+
+POM_SCM_URL=https://github.com/piashcse/zodkmp
+POM_SCM_CONNECTION=scm:git:https://github.com/piashcse/zodkmp.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com/piashcse/zodkmp.git
+
+POM_DEVELOPER_ID=piashcse
+POM_DEVELOPER_NAME=Mehedi Hassan Piash
+POM_DEVELOPER_EMAIL=piash599@gmail.com

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlinx-datetime = "0.6.0"
 composeMultiplatform = "1.9.0"
 junit = "4.13.2"
 kotlin = "2.2.20"
+mavenPublish = "0.34.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -33,3 +34,4 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/zodkmp/build.gradle.kts
+++ b/zodkmp/build.gradle.kts
@@ -3,8 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    `maven-publish`
-    signing
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {
@@ -52,110 +51,34 @@ android {
     }
 }
 
-// Create javadoc and sources JARs for Maven Central compliance
-val javadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
-    // Empty Javadoc JAR - required by Maven Central but can be empty if no docs exist
-}
+// Configure publishing with vanniktech plugin - automatically configured by plugin for Kotlin Multiplatform
+mavenPublishing {
+    pom {
+        name = findProperty("POM_NAME")?.toString() ?: "ZodKmp"
+        description = findProperty("POM_DESCRIPTION")?.toString() ?: "A Kotlin Multiplatform library for Zod-like validation"
+        inceptionYear = findProperty("POM_INCEPTION_YEAR")?.toString() ?: "2024"
+        url = findProperty("POM_URL")?.toString() ?: "https://github.com/piashcse/zodkmp"
 
-val allSourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    // Include sources from all relevant source sets
-    from(kotlin.sourceSets.commonMain.get().kotlin.srcDirs)
-}
-
-// Add artifacts to all publications
-publishing {
-    publications.withType<MavenPublication> {
-        artifact(javadocJar.get())
-        artifact(allSourcesJar.get())
-    }
-}
-
-// Configure publications for Maven Central
-publishing {
-    publications {
-        withType<MavenPublication> {
-            // Configure artifact IDs for different variants
-            // Only set artifactId for main publications to avoid conflicts
-            if (name == "kotlinMultiplatform") {
-                artifactId = "zodkmp"
-            } else if (name == "androidRelease") {
-                artifactId = "zodkmp"
-            } else if (name == "androidDebug") {
-                artifactId = "zodkmp"
-            } else if (name.startsWith("ios")) {
-                // Set consistent artifact ID for iOS targets
-                artifactId = "zodkmp"
+        licenses {
+            license {
+                name = findProperty("POM_LICENSE_NAME")?.toString() ?: "MIT License"
+                url = findProperty("POM_LICENSE_URL")?.toString() ?: "https://opensource.org/licenses/MIT"
+                distribution = findProperty("POM_LICENSE_DIST")?.toString() ?: "repo"
             }
-            
-            pom {
-                name.set("ZodKmp")
-                description.set("A Kotlin Multiplatform library for Zod-like validation")
-                url.set("https://github.com/piashcse/zodkmp")
-                
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://opensource.org/licenses/MIT")
-                        distribution.set("repo")
-                    }
-                }
-                
-                developers {
-                    developer {
-                        id.set("piashcse")
-                        name.set("Mehedi Hassan Piash")
-                        email.set("piash599@gmail.com")
-                        organization.set("piashcse")
-                        organizationUrl.set("https://github.com/piashcse")
-                    }
-                }
-                
-                scm {
-                    connection.set("scm:git:https://github.com/piashcse/zodkmp.git")
-                    developerConnection.set("scm:git:ssh://github.com/piashcse/zodkmp.git")
-                    url.set("https://github.com/piashcse/zodkmp")
-                }
+        }
+
+        developers {
+            developer {
+                id = findProperty("POM_DEVELOPER_ID")?.toString() ?: "piashcse"
+                name = findProperty("POM_DEVELOPER_NAME")?.toString() ?: "Mehedi Hassan Piash"
+                url = findProperty("POM_URL")?.toString() ?: "https://github.com/piashcse"
             }
+        }
+
+        scm {
+            url = findProperty("POM_SCM_URL")?.toString() ?: "https://github.com/piashcse/zodkmp"
+            connection = findProperty("POM_SCM_CONNECTION")?.toString() ?: "scm:git:https://github.com/piashcse/zodkmp.git"
+            developerConnection = findProperty("POM_SCM_DEV_CONNECTION")?.toString() ?: "scm:git:ssh://github.com/piashcse/zodkmp.git"
         }
     }
-    
-    repositories {
-        maven {
-            name = "Central"
-            setUrl("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_PASSWORD")
-            }
-        }
-        
-        maven {
-            name = "Snapshot"
-            setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_PASSWORD")
-            }
-        }
-        
-        // For testing purposes - local repository
-        maven {
-            name = "Local"
-            url = uri("$buildDir/repository")
-        }
-    }
-}
-
-// Signing configuration
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("SIGNING_KEY"),
-        System.getenv("SIGNING_PASSWORD")
-    )
-    sign(publishing.publications)
-    // Only require signing when explicitly building for publication (not for JitPack or when skipSigning is set)
-    isRequired = !project.hasProperty("skipSigning") && System.getenv("JITPACK") != "true" && 
-                 !project.findProperty("skipSigning").toString().toBoolean()
 }


### PR DESCRIPTION
This commit refactors the publishing process to Maven Central by replacing the manual `maven-publish` and `signing` configuration with the `com.vanniktech.maven.publish` plugin. This significantly simplifies the build scripts and standardizes the process.

Key changes:
- **Replaced Manual Publishing:** Removed the extensive manual configuration for `maven-publish`, `signing`, Javadoc/sources JAR creation, and repository definitions from `zodkmp/build.gradle.kts`.
- **Adopted Vanniktech Plugin:** Added `com.vanniktech.maven.publish` plugin to `libs.versions.toml` and applied it in `zodkmp/build.gradle.kts`.
- **Externalized Configuration:** All POM metadata and library coordinates (group, version, artifactId, developer info, SCM, etc.) are now defined in `gradle.properties` and read dynamically in the build script. This makes configuration more centralized and easier to manage.
- **Simplified CI/CD:** The `.github/workflows/publish.yml` workflow is updated to trigger on GitHub releases. It now uses a single command, `./gradlew publishToMavenCentral`, and relies on environment variables prefixed with `ORG_GRADLE_PROJECT_` for credentials, as recommended by the vanniktech plugin.
- **Updated Documentation:** The `README.md` has been updated to reflect the new, simpler publishing process, including changes to required GitHub secrets and local verification commands.