### PR TITLE
refactor: Configure Maven Central publishing coordinates

### DIFF
--- a/zodkmp/build.gradle.kts
+++ b/zodkmp/build.gradle.kts
@@ -51,8 +51,14 @@ android {
     }
 }
 
-// Configure publishing with vanniktech plugin - automatically configured by plugin for Kotlin Multiplatform
+// Configure publishing with vanniktech plugin for Maven Central
 mavenPublishing {
+    publishToMavenCentral()
+    coordinates(
+        artifactId = findProperty("POM_ARTIFACT_ID")?.toString() ?: "zodkmp", 
+        version = version.toString()
+    )
+
     pom {
         name = findProperty("POM_NAME")?.toString() ?: "ZodKmp"
         description = findProperty("POM_DESCRIPTION")?.toString() ?: "A Kotlin Multiplatform library for Zod-like validation"


### PR DESCRIPTION
This commit updates the `build.gradle.kts` file to explicitly configure the publishing settings for Maven Central using the `vanniktech.maven.publish` plugin.

Key changes:
- Added `publishToMavenCentral()` to target the Maven Central repository.
- Defined the artifact coordinates (`artifactId` and `version`) for the project, allowing them to be sourced from Gradle properties.