### PR TITLE
feat: Expand multiplatform support

### DIFF
--- a/zodkmp/build.gradle.kts
+++ b/zodkmp/build.gradle.kts
@@ -13,8 +13,21 @@ kotlin {
         }
     }
     
+    jvm("desktop")
+    
+    js {
+        browser()
+        nodejs()
+    }
+    
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+    
     listOf(
         iosArm64(),
+        iosX64(),  // Adding iosX64 target
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
@@ -22,6 +35,28 @@ kotlin {
             isStatic = true
         }
     }
+
+    // Add macOS targets
+    macosX64()
+    macosArm64()
+    
+    // Add tvOS targets
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    
+    // Add watchOS targets
+    watchosArm32()
+    watchosArm64()
+    watchosX64()
+    watchosSimulatorArm64()
+    
+    // Add Linux targets
+    linuxX64()
+    linuxArm64()
+    
+    // Add Windows targets
+    mingwX64()
     
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
This commit significantly expands the range of supported targets for the `zodkmp` library, enhancing its cross-platform capabilities.

Support has been added for the following platforms:
- **JVM**: `desktop`
- **JavaScript**: `js` (browser and nodejs) and `wasmJs`
- **iOS**: `iosX64` for simulators on Intel Macs
- **macOS**: `macosX64` and `macosArm64`
- **tvOS**: `tvosArm64`, `tvosX64`, and `tvosSimulatorArm64`
- **watchOS**: `watchosArm32`, `watchosArm64`, `watchosX64`, and `watchosSimulatorArm64`
- **Linux**: `linuxX64` and `linuxArm64`
- **Windows**: `mingwX64`