### PR TITLE
chore: Bump version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("io.github.piashcse:zodkmp:1.0.0")
+                implementation("io.github.piashcse:zodkmp:1.1.0")
             }
         }
     }
@@ -46,7 +46,7 @@ kotlin {
 
 ```toml
 [versions]
-zodkmp = "1.0.0"
+zodkmp = "1.1.0"
 
 [libraries]
 zodkmp = { module = "io.github.piashcse:zodkmp", version.ref = "zodkmp" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ SONATYPE_HOST=CENTRAL
 RELEASE_SIGNING_ENABLED=true
 
 # Library coordinates
-library.version=1.0.0
+library.version=1.1.0
 GROUP=io.github.piashcse
 POM_ARTIFACT_ID=zodkmp
 


### PR DESCRIPTION
This commit updates the project version from 1.0.0 to 1.1.0.

Specifically, the following files have been changed:
- `gradle.properties`: The `library.version` is set to `1.1.0`.
- `README.md`: The usage examples in the documentation are updated to reflect the new version `1.1.0`.