### PR TITLE
chore: Remove tvOS and watchOS targets and bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ SONATYPE_HOST=CENTRAL
 RELEASE_SIGNING_ENABLED=true
 
 # Library coordinates
-library.version=1.1.0
+library.version=1.2.0
 GROUP=io.github.piashcse
 POM_ARTIFACT_ID=zodkmp
 

--- a/zodkmp/build.gradle.kts
+++ b/zodkmp/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
     
     listOf(
         iosArm64(),
-        iosX64(),  // Adding iosX64 target
+        iosX64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
@@ -39,17 +39,6 @@ kotlin {
     // Add macOS targets
     macosX64()
     macosArm64()
-    
-    // Add tvOS targets
-    tvosArm64()
-    tvosX64()
-    tvosSimulatorArm64()
-    
-    // Add watchOS targets
-    watchosArm32()
-    watchosArm64()
-    watchosX64()
-    watchosSimulatorArm64()
     
     // Add Linux targets
     linuxX64()


### PR DESCRIPTION
- The library version has been updated from 1.1.0 to 1.2.0.