### PR TITLE
feat: Add example support for Desktop and Web (WASM)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -12,6 +13,18 @@ kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }
+    }
+    
+    jvm("desktop")
+    
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs {
+        browser {
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
     }
     
     listOf(
@@ -40,6 +53,11 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(projects.zodkmp)
+        }
+        val desktopMain by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+            }
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
@@ -78,3 +96,13 @@ dependencies {
     debugImplementation(compose.uiTooling)
 }
 
+compose.desktop {
+    application {
+        mainClass = "com.piashcse.zodkmp.MainKt"
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "com.piashcse.zodkmp"
+            packageVersion = "1.0.0"
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/piashcse/zodkmp/Platform.kt
+++ b/composeApp/src/desktopMain/kotlin/com/piashcse/zodkmp/Platform.kt
@@ -1,0 +1,7 @@
+package com.piashcse.zodkmp
+
+class DesktopPlatform : Platform {
+    override val name: String = "Desktop"
+}
+
+actual fun getPlatform(): Platform = DesktopPlatform()

--- a/composeApp/src/desktopMain/kotlin/com/piashcse/zodkmp/main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/piashcse/zodkmp/main.kt
@@ -1,0 +1,29 @@
+package com.piashcse.zodkmp
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+
+fun main() = application {
+    Window(
+        title = "ZodKmp",
+        state = rememberWindowState(width = 800.dp, height = 600.dp),
+        onCloseRequest = ::exitApplication
+    ) {
+        MaterialTheme {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background
+            ) {
+                ZodKmpModernExample()
+            }
+        }
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/com/piashcse/zodkmp/Platform.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/piashcse/zodkmp/Platform.kt
@@ -1,0 +1,7 @@
+package com.piashcse.zodkmp
+
+class WasmJsPlatform: Platform {
+    override val name: String = "Web with WASM"
+}
+
+actual fun getPlatform(): Platform = WasmJsPlatform()

--- a/composeApp/src/wasmJsMain/kotlin/com/piashcse/zodkmp/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/piashcse/zodkmp/main.kt
@@ -1,0 +1,12 @@
+package com.piashcse.zodkmp
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ZodKmp</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/composeApp/src/wasmJsMain/resources/styles.css
+++ b/composeApp/src/wasmJsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,9 @@ org.gradle.caching=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
+# Compose Multiplatform
+org.jetbrains.compose.experimental.wasm.enabled=true
+
 # Maven Central
 SONATYPE_HOST=CENTRAL
 RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
**Desktop Support:**
- A `desktop` source set has been added with its own platform-specific implementation.
- The entry point `main.kt` is configured to launch a Compose for Desktop window, which displays the existing `ZodKmpModernExample`.
- The Gradle build is updated to configure the desktop application, including the main class and native distribution formats (`.dmg`, `.msi`, `.deb`).

**Web (WASM) Support:**
- The experimental Compose for Web (WASM) target (`wasmJs`) has been enabled in `gradle.properties`.
- A `wasmJs` source set is introduced, containing the platform implementation and the `main.kt` entry point that renders the `App` within a `ComposeViewport`.
- Basic web resources (`index.html`, `styles.css`) have been added to host the WASM application.
- Webpack is configured to output `composeApp.js`.