### PR TITLE
feat: Add MkDocs documentation site and bump version script

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
 4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
+
 ## 👨 Developed By
 
 <a href="https://twitter.com/piashcse" target="_blank">

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,0 +1,30 @@
+# Advanced Usage
+
+## Error Handling
+
+ZodKmp provides detailed error information:
+
+```kotlin
+val userSchema = Zod.objectSchema<User>({
+    string("name", Zod.string().min(2))
+    string("email", Zod.string().email())
+}) { map ->
+    User(
+        name = map["name"] as String,
+        email = map["email"] as String
+    )
+}
+
+val result = userSchema.safeParse(mapOf("name" to "A", "email" to "invalid-email"))
+
+when (result) {
+    is ZodResult.Success -> {
+        println("Valid data: ${result.data}")
+    }
+    is ZodResult.Failure -> {
+        result.error.errors.forEach { error ->
+            println("Validation error: $error")
+        }
+    }
+}
+```

--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -1,0 +1,40 @@
+# Collections
+
+## Arrays
+
+Validate array values with constraints:
+
+```kotlin
+val stringArray = Zod.array(Zod.string())
+
+// With constraints
+val constrainedArray = Zod.array(Zod.string())
+    .min(2, "Array must have at least 2 elements")
+    .max(10, "Array must have at most 10 elements")
+    .length(5, "Array must have exactly 5 elements")
+    .nonempty("Array must not be empty")
+```
+
+## Tuples
+
+Validate fixed-length arrays with specific types for each position:
+
+```kotlin
+val coordinates = Zod.tuple(listOf(Zod.number(), Zod.number()))
+
+// Usage
+val result = coordinates.safeParse(listOf(10.0, 20.0))
+```
+
+## Records
+
+Validate objects with string keys and uniform value types:
+
+```kotlin
+val stringRecord = Zod.record(Zod.string())
+val numberRecord = Zod.record(Zod.number())
+
+// Usage
+val userData = mapOf("name" to "John", "city" to "NYC")
+val result = stringRecord.safeParse(userData)
+```

--- a/docs/api/enums.md
+++ b/docs/api/enums.md
@@ -1,0 +1,14 @@
+# Enums
+
+## String Enums
+
+Validate enum values:
+
+```kotlin
+// String enums
+val roleSchema = Zod.enum("admin", "user", "guest")
+
+// Using collections
+val roles = listOf("admin", "user", "guest")
+val roleSchema = Zod.enum(roles)
+```

--- a/docs/api/intersections.md
+++ b/docs/api/intersections.md
@@ -1,0 +1,21 @@
+# Intersections
+
+## Intersections
+
+Validate values that must satisfy multiple schemas:
+
+```kotlin
+val personSchema = Zod.objectSchema<Person>({
+    string("name", Zod.string())
+}) { map ->
+    Person(name = map["name"] as String)
+}
+
+val employeeSchema = Zod.objectSchema<Employee>({
+    string("employeeId", Zod.string())
+}) { map ->
+    Employee(employeeId = map["employeeId"] as String)
+}
+
+val personEmployeeSchema = Zod.intersection(personSchema, employeeSchema)
+```

--- a/docs/api/objects.md
+++ b/docs/api/objects.md
@@ -1,0 +1,63 @@
+# Objects
+
+## Basic Object Validation
+
+Validate complex objects:
+
+```kotlin
+val userSchema = Zod.objectSchema<User>({
+    string("name", Zod.string().min(2))
+    string("email", Zod.string().email())
+    number("age", Zod.number().min(0).max(120))
+    field("isActive", Zod.boolean().default(true))
+}) { map ->
+    User(
+        name = map["name"] as String,
+        email = map["email"] as String,
+        age = (map["age"] as Number).toDouble(),
+        isActive = map["isActive"] as? Boolean ?: true
+    )
+}
+```
+
+## Strict Objects
+
+Strict objects (reject unknown keys):
+
+```kotlin
+val strictUserSchema = Zod.objectSchema<User>({
+    string("name", Zod.string().min(2))
+    string("email", Zod.string().email())
+}) { map ->
+    User(
+        name = map["name"] as String,
+        email = map["email"] as String
+    )
+}.strict()
+```
+
+## Nested Object Validation
+
+```kotlin
+val addressSchema = Zod.objectSchema<Address>({
+    string("street", Zod.string().min(5))
+    string("city", Zod.string().min(2))
+    string("zipCode", Zod.string().regex(Regex("\\d{5}"))
+}) { map ->
+    Address(
+        street = map["street"] as String,
+        city = map["city"] as String,
+        zipCode = map["zipCode"] as String
+    )
+}
+
+val userWithAddressSchema = Zod.objectSchema<UserWithAddress>({
+    string("name", Zod.string().min(2))
+    field("address", addressSchema)
+}) { map ->
+    UserWithAddress(
+        name = map["name"] as String,
+        address = map["address"] as Address
+    )
+}
+```

--- a/docs/api/primitives.md
+++ b/docs/api/primitives.md
@@ -1,0 +1,125 @@
+# Primitives
+
+## String
+
+Validate string values with various constraints:
+
+```kotlin
+val stringSchema = Zod.string()
+
+// With constraints
+val constrainedString = Zod.string()
+    .min(5, "String must be at least 5 characters")
+    .max(100, "String must be at most 100 characters")
+    .length(10, "String must be exactly 10 characters")
+    .email("Must be a valid email address")
+    .url("Must be a valid URL")
+    .regex(Regex("^[A-Za-z]+$"), "Must contain only letters")
+    .startsWith("Hello", "Must start with 'Hello'")
+    .endsWith("World", "Must end with 'World'")
+    .includes("test", "Must contain 'test'")
+    .toLowerCase()
+    .toUpperCase()
+    .trim()
+```
+
+## Number
+
+Validate numeric values:
+
+```kotlin
+val numberSchema = Zod.number()
+
+// With constraints
+val constrainedNumber = Zod.number()
+    .gt(0, "Must be greater than 0")
+    .gte(5, "Must be greater than or equal to 5")
+    .lt(100, "Must be less than 100")
+    .lte(50, "Must be less than or equal to 50")
+    .min(10, "Must be at least 10")
+    .max(90, "Must be at most 90")
+    .int("Must be an integer")
+    .positive("Must be positive")
+    .negative("Must be negative")
+    .nonPositive("Must be non-positive")
+    .nonNegative("Must be non-negative")
+    .multipleOf(5, "Must be a multiple of 5")
+```
+
+## Boolean
+
+Validate boolean values:
+
+```kotlin
+val booleanSchema = Zod.boolean()
+```
+
+## Date
+
+Validate date values:
+
+```kotlin
+val dateSchema = Zod.date()
+
+// With constraints
+val constrainedDate = Zod.date()
+    .min(LocalDateTime(2020, 1, 1, 0, 0), "Date must be after 2020")
+    .max(LocalDateTime(2030, 12, 31, 23, 59), "Date must be before 2030")
+```
+
+## Null & Undefined
+
+Validate null and undefined values:
+
+```kotlin
+val nullSchema = Zod.null()
+val undefinedSchema = Zod.undefined()
+```
+
+## Literals
+
+Validate exact literal values:
+
+```kotlin
+val literalSchema = Zod.literal("admin")
+val numberLiteral = Zod.literal(42)
+val booleanLiteral = Zod.literal(true)
+```
+
+## Nullables
+
+Mark schemas as accepting null values:
+
+```kotlin
+val nullableString = Zod.string().nullable()
+
+// Usage
+val result1 = nullableString.safeParse("hello") // Success
+val result2 = nullableString.safeParse(null)   // Success
+val result3 = nullableString.safeParse(42)       // Failure
+```
+
+## Optionals
+
+Mark schemas as accepting undefined values:
+
+```kotlin
+val optionalString = Zod.string().optional()
+
+// Usage
+val result1 = optionalString.safeParse("hello") // Success
+val result2 = optionalString.safeParse(null)     // Success (undefined)
+```
+
+## Defaults
+
+Provide default values for schemas:
+
+```kotlin
+val stringWithDefault = Zod.string().default("unknown")
+val numberWithDefault = Zod.number().default { 0.0 }
+
+// Usage
+val result1 = stringWithDefault.safeParse(null)     // Success with "unknown"
+val result2 = stringWithDefault.safeParse("hello")  // Success with "hello"
+```

--- a/docs/api/refinements.md
+++ b/docs/api/refinements.md
@@ -1,0 +1,31 @@
+# Refinements
+
+## Refinements
+
+Add custom validation rules:
+
+```kotlin
+val evenNumber = Zod.number().refine({ it.toInt() % 2 == 0 }) { "Number must be even" }
+val strongPassword = Zod.string().refine({ it.length >= 8 && it.any { char -> char.isDigit() } }) { "Password must be at least 8 characters with numbers" }
+```
+
+## Conditional Validation
+
+```kotlin
+// Custom validation based on other fields
+val conditionalSchema = Zod.objectSchema<Conditional>({
+    string("type", Zod.enum("email", "phone"))
+    string("value", Zod.string())
+}) { map ->
+    Conditional(
+        type = map["type"] as String,
+        value = map["value"] as String
+    )
+}.refine({ obj ->
+    when (obj.type) {
+        "email" -> obj.value.contains("@")
+        "phone" -> obj.value.all { it.isDigit() || it == '-' }
+        else -> true
+    }
+}) { "Value must match the selected type" }
+```

--- a/docs/api/transformations.md
+++ b/docs/api/transformations.md
@@ -1,0 +1,13 @@
+# Transformations
+
+## Transformations
+
+Transform values during validation:
+
+```kotlin
+val uppercaseString = Zod.string().transform { it.uppercase() }
+val toString = Zod.number().transform { it.toInt().toString() }
+
+// Usage
+val result = toString.safeParse(42.5) // Success with "42"
+```

--- a/docs/api/unions.md
+++ b/docs/api/unions.md
@@ -1,0 +1,22 @@
+# Unions
+
+## Basic Unions
+
+Validate values that match any of multiple schemas:
+
+```kotlin
+val stringOrNumber = Zod.union(Zod.string(), Zod.number())
+val complexUnion = Zod.union(
+    Zod.string(),
+    Zod.number(),
+    Zod.objectSchema<Point>({
+        number("x", Zod.number())
+        number("y", Zod.number())
+    }) { map ->
+        Point(
+            x = (map["x"] as Number).toDouble(),
+            y = (map["y"] as Number).toDouble()
+        )
+    }
+)
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## [1.2.0] - 2024-10-06
+
+### What's Changed
+- docs: Update README and project metadata by @piashcse in #10
+- refactor: Shorten app bar title by @piashcse in #11
+- Unit test by @piashcse in #12
+- chore: Remove tvOS and watchOS targets and bump version by @piashcse in #13
+
+**Full Changelog**: [1.1.0...1.2.0](https://github.com/piashcse/ZodKmp/compare/1.1.0...1.2.0)
+
+---
+
+## [1.1.0] - 2024-10-04
+
+### What's Changed
+- feat: Expand multiplatform support by @piashcse in #7
+- chore: Bump version to 1.1.0 by @piashcse in #8
+- Code optimization by @piashcse in #9
+
+**Full Changelog**: [1.0.0...1.1.0](https://github.com/piashcse/ZodKmp/compare/1.0.0...1.1.0)
+
+---
+
+## [1.0.0] - 2024-10-04
+
+### What's Changed
+- feat: Implement comprehensive validation schemas and UI by @piashcse in #1
+- Multiplatform Support: Properly configured for Android, iOS and other KMP targets by @piashcse in #2
+- Feature automate publishing by @piashcse in #3
+- fix: Disable signing for JitPack builds by @piashcse in #4
+- refactor: Simplify Maven Central publishing with vanniktech plugin by @piashcse in #5
+- refactor: Configure Maven Central publishing coordinates by @piashcse in #6
+
+### New Contributors
+- @piashcse made their first contribution in #1
+
+**Full Changelog**: [1.0.0](https://github.com/piashcse/ZodKmp/commits/1.0.0)
+
+---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## How to Contribute
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request
+
+## Development Setup
+
+To get started with development, you'll need to set up your Kotlin Multiplatform environment:
+
+1. Install the latest version of Kotlin and the Kotlin Multiplatform plugin
+2. Clone the repository
+3. Build the project using Gradle: `./gradlew build`
+4. Run the tests: `./gradlew test`
+
+## Code Style
+
+- Follow the Kotlin coding conventions
+- Write clear, well-documented code
+- Add tests for new functionality
+- Keep changes focused and minimal

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,13 @@
+/* Custom CSS for ZodKmp documentation */
+
+/* Custom styling for the documentation site */
+.md-typeset__table {
+  width: 100%;
+  display: block;
+}
+
+.md-typeset table:not([class]) {
+  display: table;
+}
+
+/* Additional customizations can be added here */

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,63 @@
+# Getting Started
+
+## Installation
+
+### Gradle
+
+Add the following to your `build.gradle.kts`:
+
+```kotlin
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("io.github.piashcse:zodkmp:1.2.0")
+            }
+        }
+    }
+}
+```
+
+### Version Catalog (libs.versions.toml)
+
+```toml
+[versions]
+zodkmp = "1.2.0"
+
+[libraries]
+zodkmp = { module = "io.github.piashcse:zodkmp", version.ref = "zodkmp" }
+```
+
+## Basic Usage
+
+ZodKmp allows you to define validation schemas and use them to validate data:
+
+```kotlin
+import com.piashcse.zodkmp.Zod
+
+// Define a schema
+val userSchema = Zod.objectSchema<User>({
+    string("name", Zod.string().min(2))
+    string("email", Zod.string().email())
+    number("age", Zod.number().min(0).max(120))
+}) { map ->
+    User(
+        name = map["name"] as String,
+        email = map["email"] as String,
+        age = (map["age"] as Number).toDouble()
+    )
+}
+
+// Use the schema
+val userData = mapOf(
+    "name" to "John Doe",
+    "email" to "john@example.com",
+    "age" to 30.0
+)
+
+val result = userSchema.safeParse(userData)
+when (result) {
+    is ZodResult.Success -> println("Valid user: ${result.data}")
+    is ZodResult.Failure -> println("Validation errors: ${result.error.errors}")
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,152 @@
+---
+hide:
+  - navigation
+---
+
+# ZodKmp: Kotlin Multiplatform Validation
+
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.piashcse/zodkmp.svg)](https://search.maven.org/artifact/io.github.piashcse/zodkmp)
+[![Kotlin Version](https://img.shields.io/badge/kotlin-2.2.20-blue.svg?logo=kotlin)](http://kotlinlang.org)
+![badge-Android](https://img.shields.io/badge/Platform-Android-brightgreen)
+![badge-iOS](https://img.shields.io/badge/Platform-iOS-lightgray)
+![badge-desktop](http://img.shields.io/badge/Platform-Desktop-4D76CD.svg?style=flat)
+![badge-web](https://img.shields.io/badge/Platform-Web-blueviolet.svg?style=flat)
+[![License](https://img.shields.io/github/license/colinhacks/zod)](LICENSE)
+<a href="https://github.com/piashcse"><img alt="License" src="https://img.shields.io/static/v1?label=GitHub&message=piashcse&color=C51162"/></a>
+
+ZodKmp is a Kotlin Multiplatform implementation of the popular [Zod](https://zod.dev/) TypeScript validation library. It provides a declarative, type-safe way to validate data in your Kotlin Multiplatform projects.
+
+## Platform Support
+
+ZodKmp supports the following platforms:
+
+- Android (JVM)
+- iOS (Native)
+- JVM
+- JS (JavaScript)
+- Native (Linux, Windows, macOS)
+
+## Features
+
+- ✅ **Declarative Schema Definition** - Define validation rules upfront
+- ✅ **Type Inference** - Automatic type inference from schemas
+- ✅ **Immutable Architecture** - Immutable schemas that return new instances
+- ✅ **Kotlin Multiplatform** - Works on Android, iOS, and other Kotlin targets
+- ✅ **Comprehensive API** - Supports all major Zod validation features
+- ✅ **Extensible** - Easy to extend with custom validations
+- ✅ **Zero Dependencies** - Lightweight with minimal footprint
+- ✅ **Excellent Error Messages** - Detailed, customizable error reporting
+
+## Getting Started
+
+### Installation
+
+#### Gradle
+
+Add the following to your `build.gradle.kts`:
+
+```kotlin
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("io.github.piashcse:zodkmp:1.2.0")
+            }
+        }
+    }
+}
+```
+
+#### Version Catalog (libs.versions.toml)
+
+```toml
+[versions]
+zodkmp = "1.2.0"
+
+[libraries]
+zodkmp = { module = "io.github.piashcse:zodkmp", version.ref = "zodkmp" }
+```
+
+### Basic Usage
+
+ZodKmp allows you to define validation schemas and use them to validate data:
+
+```kotlin
+import com.piashcse.zodkmp.Zod
+
+// Define a schema
+val userSchema = Zod.objectSchema<User>({
+    string("name", Zod.string().min(2))
+    string("email", Zod.string().email())
+    number("age", Zod.number().min(0).max(120))
+}) { map ->
+    User(
+        name = map["name"] as String,
+        email = map["email"] as String,
+        age = (map["age"] as Number).toDouble()
+    )
+}
+
+// Use the schema
+val userData = mapOf(
+    "name" to "John Doe",
+    "email" to "john@example.com",
+    "age" to 30.0
+)
+
+val result = userSchema.safeParse(userData)
+when (result) {
+    is ZodResult.Success -> println("Valid user: ${result.data}")
+    is ZodResult.Failure -> println("Validation errors: ${result.error.errors}")
+}
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request
+
+## 👨 Developed By
+
+<a href="https://twitter.com/piashcse" target="_blank">
+  <img src="https://avatars.githubusercontent.com/piashcse" width="90" align="left">
+</a>
+
+**Mehedi Hassan Piash**
+
+[![Twitter](https://img.shields.io/badge/-Twitter-1DA1F2?logo=x&logoColor=white&style=for-the-badge)](https://twitter.com/piashcse)
+[![Medium](https://img.shields.io/badge/-Medium-00AB6C?logo=medium&logoColor=white&style=for-the-badge)](https://medium.com/@piashcse)
+[![Linkedin](https://img.shields.io/badge/-LinkedIn-0077B5?logo=linkedin&logoColor=white&style=for-the-badge)](https://www.linkedin.com/in/piashcse/)
+[![Web](https://img.shields.io/badge/-Web-0073E6?logo=appveyor&logoColor=white&style=for-the-badge)](https://piashcse.github.io/)
+[![Blog](https://img.shields.io/badge/-Blog-0077B5?logo=readme&logoColor=white&style=for-the-badge)](https://piashcse.blogspot.com)
+
+## License
+
+```
+MIT License
+
+Copyright (c) 2025 Mehedi Hassan Piash
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,25 @@
+# License
+
+```
+MIT License
+
+Copyright (c) 2025 Mehedi Hassan Piash
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,57 @@
+site_name: ZodKmp
+site_description: ZodKmp is a Kotlin Multiplatform implementation of the popular Zod TypeScript validation library. It provides a declarative, type-safe way to validate data in your Kotlin Multiplatform projects.
+
+theme:
+  name: material
+  icon:
+    logo: material/library
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: green
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  features:
+   - navigation.tabs  # 👈 enables top tab bar
+  hide:
+   - navigation
+
+nav:
+  - Home: index.md
+  - API Reference:
+    - Primitives: api/primitives.md
+    - Objects: api/objects.md
+    - Collections: api/collections.md
+    - Unions: api/unions.md
+    - Enums: api/enums.md
+    - Intersections: api/intersections.md
+    - Transformations: api/transformations.md
+    - Refinements: api/refinements.md
+  - Changelog: changelog.md
+
+repo_url: https://github.com/piashcse/zodkmp
+edit_uri: edit/main/docs/
+
+extra_css:
+  - css/extra.css
+plugins:
+  - search
+  - meta  # 👈 Required for per-page 'hide' to work
+
+markdown_extensions:
+  - markdown.extensions.admonition
+  - markdown.extensions.codehilite
+  - markdown.extensions.extra
+  - markdown.extensions.toc:
+      permalink: true


### PR DESCRIPTION
**New Features:**

- **MkDocs Site:** A comprehensive documentation site has been created under the `docs/` and `site/` directories. This includes:
  -   `mkdocs.yml`: The main configuration file for the site, defining the theme, navigation, and plugins.
  -   Markdown pages for "Getting Started," "Contributing," "Changelog," and detailed API references for primitives, objects, collections, and other validation types.
  -   Static assets including CSS for custom styling and all necessary JavaScript bundles for the Material theme.

**Documentation Content Added:**
- `index.md`: Main landing page for the documentation.
- `getting-started.md`: Installation and basic usage guide.
- `advanced-usage.md`: Covers more complex topics like error handling.
- API reference pages for: `collections.md`, `enums.md`, `intersections.md`, `objects.md`, `primitives.md`, `refinements.md`, `transformations.md`, and `unions.md`.
- `changelog.md`: A manually maintained changelog.
- `contributing.md` & `license.md`: Project contribution guidelines and license information.
