### PR TITLE
add typeSafeObjectSchema and its tests

### DIFF
--- a/zodkmp/src/commonMain/kotlin/com/piashcse/zodkmp/Zod.kt
+++ b/zodkmp/src/commonMain/kotlin/com/piashcse/zodkmp/Zod.kt
@@ -26,7 +26,12 @@ object Zod {
         shapeBuilder: ZodObjectShapeBuilder.() -> Unit,
         noinline parser: (Map<String, Any?>) -> T
     ) = ZodObjectSchema.build(shapeBuilder, parser)
-    
+
+    inline fun <reified T> typesafeObjectSchema(
+        shapeBuilder: ZodTypesafeObjectShapeBuilder<T>.() -> Unit,
+        noinline parser: (TypeSafeParsed<T>) -> T
+    ) = ZodTypesafeObjectSchema.build(shapeBuilder, parser)
+
     fun <T> literal(value: T) = ZodLiteral.schema(value)
     
     fun <T> literal(vararg values: T): ZodSchema<T> = ZodLiteral.schema(*values)
@@ -66,7 +71,7 @@ object Zod {
     ): ZodDiscriminatedUnion<T> = ZodDiscriminatedUnion.schema(discriminator, options)
     
     fun <T, U> intersection(left: ZodSchema<T>, right: ZodSchema<U>) = ZodIntersection.schema(left, right)
-    
+
     fun <I> preprocess(preprocessor: (Any?) -> Any?, schema: ZodSchema<I>): ZodPreprocess<I> = ZodPreprocess.schema(schema, preprocessor)
     
     fun <T, R> pipe(first: ZodSchema<T>, second: ZodSchema<R>): ZodPipe<T, R> = ZodPipe.schema(first, second)

--- a/zodkmp/src/commonMain/kotlin/com/piashcse/zodkmp/ZodTypesafeObjectSchema.kt
+++ b/zodkmp/src/commonMain/kotlin/com/piashcse/zodkmp/ZodTypesafeObjectSchema.kt
@@ -1,0 +1,128 @@
+package com.piashcse.zodkmp
+
+import kotlin.reflect.KProperty1
+
+/**
+ * Schema for validating objects
+ */
+data class ZodTypesafeObjectSchema<T>(
+    private val shape: Map<PropertyContainer<T, *>, ZodSchema<*>>,
+    private val parser: (TypeSafeParsed<T>) -> T,
+    private val strict: Boolean = false
+) : ZodSchema<T> {
+
+    fun strict(): ZodTypesafeObjectSchema<T> = copy(strict = true)
+
+    override fun parse(input: Any?): T {
+        return when (val result = safeParse(input)) {
+            is ZodResult.Success -> result.data
+            is ZodResult.Failure -> throw IllegalArgumentException(
+                "Validation failed: ${
+                    result.error.errors.joinToString(
+                        ", "
+                    )
+                }"
+            )
+        }
+    }
+
+    override fun safeParse(input: Any?): ZodResult<T> {
+        val mapInput = input as? Map<*, *>
+        if (mapInput == null) {
+            return ZodResult.Failure(ZodError("Expected object, received ${input?.let { it::class.simpleName } ?: "null"}"))
+        }
+
+        val stringKeys = mapInput.mapKeys { it.key.toString() }
+
+        val errors = mutableListOf<String>()
+
+        val parsedValues = mutableMapOf<PropertyContainer<T, *>, Any?>()
+
+        // Validate all required fields
+        for ((key, schema) in shape) {
+            val value = stringKeys[key.name]
+            when (val result = schema.safeParse(value)) {
+                is ZodResult.Success -> parsedValues[key] = result.data
+                is ZodResult.Failure -> {
+                    result.error.errors.forEach { error ->
+                        errors.add("${key.name}: $error")
+                    }
+                }
+            }
+        }
+
+        // Check for extra fields if strict mode is enabled
+        if (strict) {
+            val extraKeys = stringKeys.keys - shape.keys
+            if (extraKeys.isNotEmpty()) {
+                errors.add("Unrecognized key(s) in object: ${extraKeys.joinToString(", ")}")
+            }
+        }
+
+        return if (errors.isEmpty()) {
+            try {
+                ZodResult.Success(parser(TypeSafeParsed(parsedValues)))
+            } catch (e: Exception) {
+                ZodResult.Failure(ZodError("Failed to construct object: ${e.message}"))
+            }
+        } else {
+            ZodResult.Failure(ZodError(errors))
+        }
+    }
+
+    companion object {
+        fun <T> create(
+            shape: Map<PropertyContainer<T, *>, ZodSchema<*>>,
+            parser: (TypeSafeParsed<T>) -> T,
+            strict: Boolean = false
+        ): ZodTypesafeObjectSchema<T> {
+            return ZodTypesafeObjectSchema(shape, parser, strict)
+        }
+
+        inline fun <reified T> build(
+            shapeBuilder: ZodTypesafeObjectShapeBuilder<T>.() -> Unit,
+            noinline parser: (TypeSafeParsed<T>) -> T
+        ): ZodTypesafeObjectSchema<T> {
+            val builder = ZodTypesafeObjectShapeBuilder<T>()
+            builder.shapeBuilder()
+            return ZodTypesafeObjectSchema(builder.shape, parser, false)
+        }
+    }
+}
+
+data class PropertyContainer<T, R>(
+    val property: KProperty1<T, R>,
+    val name: String,
+)
+
+class ZodTypesafeObjectShapeBuilder<T> {
+    val shape: MutableMap<PropertyContainer<T, *>, ZodSchema<*>> = mutableMapOf()
+
+    infix fun <R>KProperty1<T, R>.to(schema: ZodSchema<R>) {
+        shape[named(name)] = schema
+    }
+    infix fun <R> PropertyContainer<T, R>.to(schema: ZodSchema<R>) {
+        shape[this] = schema
+    }
+    fun <R>KProperty1<T, R>.named(name: String) = PropertyContainer(this, name)
+}
+
+inline fun <reified T> typeSafeObjectSchema(
+    shapeBuilder: ZodTypesafeObjectShapeBuilder<T>.()->Unit,
+    noinline parser: (TypeSafeParsed<T>) -> T
+): ZodTypesafeObjectSchema<T> {
+    return ZodTypesafeObjectSchema.build(
+        shapeBuilder = shapeBuilder,
+        parser = parser
+    )
+}
+
+class TypeSafeParsed<T> internal constructor(private val from: Map<PropertyContainer<T, *>, Any?>) {
+
+    private val mapped = from.keys.associateBy { it.property }
+
+    operator fun <R> get(kProperty1: KProperty1<T, R>): R {
+        @Suppress("UNCHECKED_CAST")
+        return from[mapped[kProperty1]] as R
+    }
+}

--- a/zodkmp/src/commonTest/kotlin/com/piashcse/zodkmp/ZodTypesafeObjectTest.kt
+++ b/zodkmp/src/commonTest/kotlin/com/piashcse/zodkmp/ZodTypesafeObjectTest.kt
@@ -1,0 +1,172 @@
+package com.piashcse.zodkmp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ZodTypesafeObjectTest {
+    data class User(val name: String, val age: Double)
+    data class Product(val id: Int, val name: String, val price: Double)
+
+    @Test
+    fun `parse should succeed with valid object`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create<User>(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], map[User::age]) }
+        )
+        
+        val validData = mapOf("name" to "John", "age" to 30.0)
+        val result = userSchema.parse(validData)
+        assertEquals(User("John", 30.0), result)
+    }
+
+    @Test
+    fun `parse should throw with invalid object`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], map[User::age]) }
+        )
+        
+        val invalidData = mapOf("name" to "John", "age" to "not a number")
+        assertFailsWith<IllegalArgumentException> {
+            userSchema.parse(invalidData)
+        }
+    }
+
+    @Test
+    fun `safeParse should return Success with valid object`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], (map[User::age])) }
+        )
+        
+        val validData = mapOf("name" to "John", "age" to 30.0)
+        val result = userSchema.safeParse(validData)
+        assertTrue(result is ZodResult.Success<*>)
+        @Suppress("UNCHECKED_CAST")
+        val userData = result.data as User
+        assertEquals(User("John", 30.0), userData)
+    }
+
+    @Test
+    fun `safeParse should return Failure with invalid object`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create<User>(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], map[User::age]) }
+        )
+        
+        val invalidData = mapOf("name" to "John", "age" to "not a number")
+        val result = userSchema.safeParse(invalidData)
+        assertTrue(result is ZodResult.Failure)
+        assertTrue(result.error.errors.any { it.contains("age") })
+    }
+
+    @Test
+    fun `safeParse should return Failure with non-object input`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create<User>(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], map[User::age]) }
+        )
+        
+        val result = userSchema.safeParse("not an object")
+        assertTrue(result is ZodResult.Failure)
+        assertTrue(result.error.errors.first().contains("Expected object"))
+    }
+
+    @Test
+    fun `strict mode should reject extra fields`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], map[User::age]) },
+            strict = true
+        )
+        
+        val dataWithExtra = mapOf("name" to "John", "age" to 30.0, "extra" to "field")
+        val result = userSchema.safeParse(dataWithExtra)
+        assertTrue(result is ZodResult.Failure)
+        assertTrue(result.error.errors.any { it.contains("Unrecognized key") })
+    }
+
+    @Test
+    fun `missing required field should fail`() {
+        val builder = ZodTypesafeObjectShapeBuilder<User>()
+        with(builder){
+            User::name to Zod.string()
+            User::age to Zod.number()
+        }
+        val userSchema = ZodTypesafeObjectSchema.create<User>(
+            shape = builder.shape,
+            parser = { map -> User(map[User::name], map[User::age]) }
+        )
+        
+        val dataWithMissing = mapOf("name" to "John") // Missing age
+        val result = userSchema.safeParse(dataWithMissing)
+        assertTrue(result is ZodResult.Failure)
+        assertTrue(result.error.errors.any { it.contains("age") })
+    }
+
+    @Test
+    fun `optional fields using optional extensions should work`() {
+        data class Person(val name: String, val age: Double?)
+
+        val builder = ZodTypesafeObjectShapeBuilder<Person>()
+        with(builder){
+            Person::name to Zod.string()
+            Person::age to Zod.number().nullable()
+        }
+        val schema = ZodTypesafeObjectSchema.create<Person>(
+            shape = builder.shape,
+            parser = { map -> 
+                val ageValue = map[Person::age]
+                Person(map[Person::name], ageValue)
+            }
+        )
+        
+        // With optional field present
+        val dataWithAge = mapOf("name" to "John", "age" to 30.0)
+        val result1 = schema.safeParse(dataWithAge)
+        assertTrue(result1 is ZodResult.Success<*>)
+        @Suppress("UNCHECKED_CAST")
+        val person1 = result1.data as Person
+        assertEquals(Person("John", 30.0), person1)
+        
+        // With optional field absent (using null)
+        val dataWithoutAge = mapOf("name" to "John", "age" to null)
+        val result2 = schema.safeParse(dataWithoutAge)
+        assertTrue(result2 is ZodResult.Success<*>)
+        @Suppress("UNCHECKED_CAST")
+        val person2 = result2.data as Person
+        assertEquals(Person("John", null), person2)
+    }
+}


### PR DESCRIPTION
closes #18 

API usage:

```kt

import com.piashcse.zodkmp.Zod
import com.piashcse.zodkmp.default
import com.piashcse.zodkmp.transform

data class AppConfig(
    val theme: String,
    val language: String,
    val scale: Float,
)

val appConfigSchema2 = Zod.typeSafeObjectSchema<AppConfig>(
    shapeBuilder = {
        AppConfig::theme to Zod.string().default { "dark" }
        // in case of obfuscation, the actual property is not usable, so we can have a named extension here
        AppConfig::language.named("lang") to Zod.string().default { "en" }
        // the typesafe builder force you to use transform! otherwise it doesn't compile! you don't have to blindly convert [Any] into [Float] in the parser anymore
        AppConfig::scale to Zod.number().transform { it.toFloat() }
    },
    parser = {
        AppConfig(
            it[AppConfig::theme],
            it[AppConfig::language],
            it[AppConfig::scale]
        )
    }
)

fun main() {
    val parse = appConfigSchema2.safeParse(
        mapOf(
            "theme" to "darknight",
            "lang" to "fa",
            "scale" to "2"
        )
    )
    // Success(data=AppConfig(theme=darknight, language=fa, scale=2.0))
    println(parse)
}

```

